### PR TITLE
Fix white space above img elements in articles

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -296,8 +296,7 @@ main #search-by-location article {
 }
 
 .new-mark {
-    /* position: absolute; */
-    position: relative;
+    position: absolute; /* Pf9dc */
     background-color: var(--orange-color);
     color: var(--white-color);
     font-family: var(--title-font);
@@ -307,8 +306,7 @@ main #search-by-location article {
     text-align: center;
     vertical-align: middle;
     left: -7.89px;
-    /* left: 7.89px; */
-    top: 45.27px;
+    top: 0; /* P1dd5 */
     /* top: -2.71px; */
     /* margin: auto 0; */
     /* padding: 4.09px 0.73px 10.97px 15px; */


### PR DESCRIPTION
Update the `.new-mark` class in `styles/style.css` to remove white space above the `<img>` elements in `<article>` elements with the class `label-new display-mark`.

* Change the `.new-mark` class to `position: absolute;` to remove it from the document flow.
* Set `top: 0;` for the `.new-mark` class to eliminate the white space above the `<img>` elements.

