### PR TITLE
Fix regression in 'How it works' section and 'New' text positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,9 @@
         <section id="how-to">
             <h2>How it works</h2>
             <ul>
-                <li><!-- <span class="figure">1</span> --><a class="p-two-class">Enter your location</a></li>
-                <li><!-- <span class="figure">2</span> --><a class="p-two-class">Choose a professional</a></li>
-                <li><!-- <span class="figure">3</span> --><a class="p-two-class">Receive a quote</a></li>
+                <li><span class="figure">1</span><a class="p-two-class">Enter your location</a></li>
+                <li><span class="figure">2</span><a class="p-two-class">Choose a professional</a></li>
+                <li><span class="figure">3</span><a class="p-two-class">Receive a quote</a></li>
             </ul>
         </section>
         <section id="pro-list">

--- a/styles/style.css
+++ b/styles/style.css
@@ -32,7 +32,7 @@ h2 {
     font-family: var(--main-font);
     font-weight: 700;
     font-size: 24px;
-    color: var(--black-color);
+    color: var (--black-color);
     padding: 30px 0;
 }
 
@@ -169,8 +169,7 @@ main #search-by-location article {
     padding: 16px 10px;
 }
 
-
-/* #how-to ul li:nth-child(2)::before {
+#how-to ul li:nth-child(2)::before {
     content: '2';
     position: absolute;
     left: -1px;
@@ -186,7 +185,7 @@ main #search-by-location article {
     background-color: var(--orange-color);
     border-radius: 12px;
     padding: 16px 10px;
-} */
+}
 
 #how-to ul li a {
     /* padding: 20px; */
@@ -296,7 +295,7 @@ main #search-by-location article {
 }
 
 .new-mark {
-    position: absolute; /* Pf9dc */
+    position: relative; /* Pf9dc */
     background-color: var(--orange-color);
     color: var(--white-color);
     font-family: var(--title-font);


### PR DESCRIPTION
Fix the positioning of the 'New' text and display digits in the 'How it works' section.

* **index.html**
  - Uncomment the digits in the `#how-to` section.
  - Add `span` elements with class `figure` inside each `li` element in the `#how-to` section.

* **styles/style.css**
  - Update the `.new-mark` class to position the `New` text relative to the article container.
  - Uncomment the CSS for the digits in the `#how-to` section.
  - Add CSS for the `span.figure` elements in the `#how-to` section.

