### PR TITLE
Fix img elements to cover articles in pro-list section

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
             <h2>Choose your professional</h2>
             <article class="label-new display-mark">
                 <p class="new-mark">New !</p>
-                <img src="./img/constructeur1.jpg" alt="smith & sons">
+                <img class="cover" src="./img/constructeur1.jpg" alt="smith & sons">
                 <section>
                     <a href="#">
                         <h3>Smith & Sons Construction Co.</h3>
@@ -59,7 +59,7 @@
             </article>
             <article class="label-new display-mark">
                 <p class="new-mark">New !</p>
-                <img src="./img/constructeur2.jpg" alt="Greenway Builders">
+                <img class="cover" src="./img/constructeur2.jpg" alt="Greenway Builders">
                 <section>
                     <a href="#">
                         <h3>Greenway Builders</h3>

--- a/styles/style.css
+++ b/styles/style.css
@@ -37,7 +37,7 @@ h2 {
 }
 
 p {
-    font-family: var(--main-font);
+    font-family: var (--main-font);
     font-weight: 300;
     font-size: 15px;
 }
@@ -263,7 +263,7 @@ main #search-by-location article {
 .label-new {
     border-radius: 20px 20px 20px 20px;
     background-color: var(--white-color);
-    /* position: relative; */
+    position: relative; /* Pcd79 */
 }
 
 .label-new section {
@@ -363,4 +363,13 @@ footer>ul li{
 
 footer a {
     color:var(--white-color);
+}
+
+.cover {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }


### PR DESCRIPTION
Add `class="cover"` to the `img` elements within the `article` tags in the `#pro-list` section in `index.html`.

Add CSS rule for `.cover` class in `styles/style.css`:
* Set `position` to `absolute`, `top` to `0`, `left` to `0`, `width` to `100%`, `height` to `100%`, and `object-fit` to `cover`.
* Add `position: relative;` to the `.label-new` selector.

