### PR TITLE
Fix white space issue with article and img

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -264,6 +264,7 @@ main #search-by-location article {
     border-radius: 20px 20px 20px 20px;
     background-color: var(--white-color);
     position: relative; /* Pcd79 */
+    padding: 0; /* Pa015 */
 }
 
 .label-new section {


### PR DESCRIPTION
Update `styles/style.css` to fix regression issue with article and img white space.

* Remove padding from the `.label-new` selector to eliminate extra white space around images.

