### PR TITLE
Fix overlapping articles and new labels

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -263,8 +263,11 @@ main #search-by-location article {
 .label-new {
     border-radius: 20px 20px 20px 20px;
     background-color: var(--white-color);
-    position: relative; /* Pcd79 */
     padding: 0; /* Pa015 */
+}
+
+#pro-list .label-new {
+    position: relative; /* P1dd5 */
 }
 
 .label-new section {
@@ -317,7 +320,8 @@ main #search-by-location article {
 }
 
 .new-mark {
-    position: relative; /* Pf9dc */
+    position: absolute; /* Pf9dc */
+    z-index: 1; /* Pdfea */
     background-color: var(--orange-color);
     color: var(--white-color);
     font-family: var(--title-font);
@@ -373,4 +377,5 @@ footer a {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    z-index: 0; /* P71c1 */
 }


### PR DESCRIPTION
Fix the overlapping of articles and ensure "new" labels are displayed correctly.

* Change the `new-mark` class to have `position: absolute;` and `z-index: 1;` to ensure it is above other elements.
* Change the `cover` class to have `z-index: 0;` to ensure it is behind the "new" label.
* Remove the `position: relative;` from the `label-new` class.
* Add `position: relative;` to the `#pro-list .label-new` class.

